### PR TITLE
Handle missing bookmarks

### DIFF
--- a/Split_PDF_Reports.py
+++ b/Split_PDF_Reports.py
@@ -53,109 +53,107 @@ class BookmarkToPageMap(PyPDF2.PdfFileReader):
             result[title] = page_id_to_page_numbers.get(page_idnum, '???')
         return result
 
+def main(arg1, arg2, arg3, arg4):
+    ################
+    # Main Program #
+    ################
+    #Set parameters
+    sourcePDFFile = arg1
+    outputPDFDir = arg2
+    outputNamePrefix = arg3
+    deleteSourcePDF = arg4
+    targetPDFFile = 'temppdfsplitfile.pdf' # Temporary file
 
-################
-# Main Program #
-################
-#Set parameters
-sourcePDFFile = sys.argv[1]
-outputPDFDir = sys.argv[2]
-outputNamePrefix = sys.argv[3]
-deleteSourcePDF = sys.argv[4]
-targetPDFFile = 'temppdfsplitfile.pdf' # Temporary file
+    # Append backslash to output dir if necessary
+    if not outputPDFDir.endswith('\\'):
+        outputPDFDir = outputPDFDir + '\\'
 
-# Append backslash to output dir if necessary
-if not outputPDFDir.endswith('\\'):
-    outputPDFDir = outputPDFDir + '\\'
+    print('Parameters:')
+    print(sourcePDFFile)
+    print(outputPDFDir)
+    print(outputNamePrefix)
+    print(targetPDFFile)
 
-print('Parameters:')
-print(sourcePDFFile)
-print(outputPDFDir)
-print(outputNamePrefix)
-print(targetPDFFile)
-
-#Verify PDF is ready for splitting
-while not os.path.exists(sourcePDFFile):
-    print('Source PDF not found, sleeping...')
-    #Sleep
-    time.sleep(10)
+    #Verify PDF is ready for splitting
+    while not os.path.exists(sourcePDFFile):
+        print('Source PDF not found, sleeping...')
+        #Sleep
+        time.sleep(10)
     
-if os.path.exists(sourcePDFFile):
-    print('Found source PDF file')
-    #Copy file to local working directory
-    shutil.copy(sourcePDFFile, targetPDFFile)
+    if os.path.exists(sourcePDFFile):
+        print('Found source PDF file')
+        #Copy file to local working directory
+        shutil.copy(sourcePDFFile, targetPDFFile)
 
-    #Process file
-    pdfFileObj2 = open(targetPDFFile, 'rb')
-    pdfReader = PyPDF2.PdfFileReader(pdfFileObj2)
-    pdfFileObj = BookmarkToPageMap(pdfFileObj2)
+        #Process file
+        pdfFileObj2 = open(targetPDFFile, 'rb')
+        pdfReader = PyPDF2.PdfFileReader(pdfFileObj2)
+        pdfFileObj = BookmarkToPageMap(pdfFileObj2)
 
-    #Get total pages
-    numberOfPages = pdfReader.numPages
-    print('PDF # Pages: ' + str(numberOfPages))
+        #Get total pages
+        numberOfPages = pdfReader.numPages
+        print('PDF # Pages: ' + str(numberOfPages))
 
-    i = 0
-    newPageNum = 0
-    prevPageNum = 0
-    newPageName = ''
-    prevPageName = ''
-    for p,t in sorted([(v,k) for k,v in pdfFileObj.getDestinationPageNumbers().items()]):
-        template = '%-5s  %s'
-        print (template % ('Page', 'Title'))
-        print (template % (p+1,t))
+        i = 0
+        newPageNum = 0
+        prevPageNum = 0
+        newPageName = ''
+        prevPageName = ''
+        for p,t in sorted([(v,k) for k,v in pdfFileObj.getDestinationPageNumbers().items()]):
+            template = '%-5s  %s'
+            print (template % ('Page', 'Title'))
+            print (template % (p+1,t))
         
-        newPageNum = p + 1
-        newPageName = t
+            newPageNum = p + 1
+            newPageName = t
 
-        if prevPageNum == 0 and prevPageName == '':
-            print('First Page...')
+            if prevPageNum == 0 and prevPageName == '':
+                print('First Page...')
+                prevPageNum = newPageNum
+                prevPageName = newPageName
+            else:
+                print('Next Page...')
+                pdfWriter = PyPDF2.PdfFileWriter()
+                page_idx = 0 
+                for i in range(prevPageNum, newPageNum):
+                    pdfPage = pdfReader.getPage(i-1)
+                    pdfWriter.insertPage(pdfPage, page_idx)
+                    print('Added page to PDF file: ' + prevPageName + ' - Page #: ' + str(i))
+                    page_idx+=1
+                
+                pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
+                pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
+                pdfWriter.write(pdfOutputFile)
+                pdfOutputFile.close()
+                print('Created PDF file: ' + outputPDFDir + pdfFileName)
+
+            i = prevPageNum
             prevPageNum = newPageNum
             prevPageName = newPageName
-        else:
-            print('Next Page...')
-            pdfWriter = PyPDF2.PdfFileWriter()
-            page_idx = 0 
-            for i in range(prevPageNum, newPageNum):
-                pdfPage = pdfReader.getPage(i-1)
-                pdfWriter.insertPage(pdfPage, page_idx)
-                print('Added page to PDF file: ' + prevPageName + ' - Page #: ' + str(i))
-                page_idx+=1
-                
-            pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
-            pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
-            pdfWriter.write(pdfOutputFile)
-            pdfOutputFile.close()
-            print('Created PDF file: ' + outputPDFDir + pdfFileName)
 
-        i = prevPageNum
-        prevPageNum = newPageNum
-        prevPageName = newPageName
-
-    #Split the last page
-    print('Last Page...')
-    pdfWriter = PyPDF2.PdfFileWriter()
-    page_idx = 0 
-    for i in range(prevPageNum, numberOfPages + 1):
-        pdfPage = pdfReader.getPage(i-1)
-        pdfWriter.insertPage(pdfPage, page_idx)
-        print('Added page to PDF file: ' + prevPageName + ' - Page #: ' + str(i))
-        page_idx+=1
+        #Split the last page
+        print('Last Page...')
+        pdfWriter = PyPDF2.PdfFileWriter()
+        page_idx = 0 
+        for i in range(prevPageNum, numberOfPages + 1):
+            pdfPage = pdfReader.getPage(i-1)
+            pdfWriter.insertPage(pdfPage, page_idx)
+            print('Added page to PDF file: ' + prevPageName + ' - Page #: ' + str(i))
+            page_idx+=1
         
-    pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
-    pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
-    pdfWriter.write(pdfOutputFile)
-    pdfOutputFile.close()
-    print('Created PDF file: ' + outputPDFDir + pdfFileName)
+        pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
+        pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
+        pdfWriter.write(pdfOutputFile)
+        pdfOutputFile.close()
+        print('Created PDF file: ' + outputPDFDir + pdfFileName)
 
-    pdfFileObj2.close()
+        pdfFileObj2.close()
 
-    # Delete temp file
-    os.unlink(targetPDFFile)
+        # Delete temp file
+        os.unlink(targetPDFFile)
 
-    if deleteSourcePDF == True or deleteSourcePDF == "True":
-        os.unlink(sourcePDFFile)
+        if deleteSourcePDF == True or deleteSourcePDF == "True":
+            os.unlink(sourcePDFFile)
 
-
-
-    
-
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/Split_PDF_Reports.py
+++ b/Split_PDF_Reports.py
@@ -64,9 +64,10 @@ def main(arg1, arg2, arg3, arg4):
     deleteSourcePDF = arg4
     targetPDFFile = 'temppdfsplitfile.pdf' # Temporary file
 
-    # Append backslash to output dir if necessary
-    if not outputPDFDir.endswith('\\'):
-        outputPDFDir = outputPDFDir + '\\'
+    if outputPDFDir:
+        # Append backslash to output dir if necessary
+        if not outputPDFDir.endswith('\\'):
+            outputPDFDir = outputPDFDir + '\\'
 
     print('Parameters:')
     print(sourcePDFFile)
@@ -112,20 +113,21 @@ def main(arg1, arg2, arg3, arg4):
                 prevPageNum = newPageNum
                 prevPageName = newPageName
             else:
-                print('Next Page...')
-                pdfWriter = PyPDF2.PdfFileWriter()
-                page_idx = 0 
-                for i in range(prevPageNum, newPageNum):
-                    pdfPage = pdfReader.getPage(i-1)
-                    pdfWriter.insertPage(pdfPage, page_idx)
-                    print('Added page to PDF file: ' + prevPageName + ' - Page #: ' + str(i))
-                    page_idx+=1
-                
-                pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
-                pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
-                pdfWriter.write(pdfOutputFile)
-                pdfOutputFile.close()
-                print('Created PDF file: ' + outputPDFDir + pdfFileName)
+                if newPageName:
+                    print('Next Page...')
+                    pdfWriter = PyPDF2.PdfFileWriter()
+                    page_idx = 0 
+                    for i in range(prevPageNum, newPageNum):
+                        pdfPage = pdfReader.getPage(i-1)
+                        pdfWriter.insertPage(pdfPage, page_idx)
+                        print('Added page to PDF file: ' + prevPageName + ' - Page #: ' + str(i))
+                        page_idx+=1
+
+                    pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
+                    pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
+                    pdfWriter.write(pdfOutputFile)
+                    pdfOutputFile.close()
+                    print('Created PDF file: ' + outputPDFDir + pdfFileName)
 
             i = prevPageNum
             prevPageNum = newPageNum
@@ -152,8 +154,9 @@ def main(arg1, arg2, arg3, arg4):
         # Delete temp file
         os.unlink(targetPDFFile)
 
-        if deleteSourcePDF == True or deleteSourcePDF == "True":
-            os.unlink(sourcePDFFile)
+        if newPageName:
+            if deleteSourcePDF == True or deleteSourcePDF == "True":
+                os.unlink(sourcePDFFile)
 
 if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])


### PR DESCRIPTION
Append 'backslash' only if a output dir is specified, and don't create a '.pdf' file (and also don't delete source PDFs) in the situation where a bookmark doesn't exist.