### PR TITLE
Non windows outputpath resolving

### DIFF
--- a/Split_PDF_Reports.py
+++ b/Split_PDF_Reports.py
@@ -125,10 +125,11 @@ def main(arg1, arg2, arg3, arg4):
                         page_idx+=1
 
                     pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
-                    pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
+                    fullFilePath = os.path.join(outputPDFDir, pdfFileName)
+                    pdfOutputFile = open(fullFilePath, 'wb')
                     pdfWriter.write(pdfOutputFile)
                     pdfOutputFile.close()
-                    print('Created PDF file: ' + outputPDFDir + pdfFileName)
+                    print('Created PDF file: ' + fullFilePath)
 
             i = prevPageNum
             prevPageNum = newPageNum
@@ -145,10 +146,11 @@ def main(arg1, arg2, arg3, arg4):
             page_idx+=1
         
         pdfFileName = outputNamePrefix + str(str(prevPageName).replace(':','_')).replace('*','_') + '.pdf'
-        pdfOutputFile = open(outputPDFDir + pdfFileName, 'wb')
+        fullFilePath = os.path.join(outputPDFDir, pdfFileName)
+        pdfOutputFile = open(fullFilePath, 'wb')
         pdfWriter.write(pdfOutputFile)
         pdfOutputFile.close()
-        print('Created PDF file: ' + outputPDFDir + pdfFileName)
+        print('Created PDF file: ' + fullFilePath)
 
         pdfFileObj2.close()
 

--- a/Split_PDF_Reports.py
+++ b/Split_PDF_Reports.py
@@ -65,9 +65,10 @@ def main(arg1, arg2, arg3, arg4):
     targetPDFFile = 'temppdfsplitfile.pdf' # Temporary file
 
     if outputPDFDir:
-        # Append backslash to output dir if necessary
-        if not outputPDFDir.endswith('\\'):
-            outputPDFDir = outputPDFDir + '\\'
+        if os.path.exists(outputPDFDir):
+            pass
+        else:
+            os.mkdir(outputPDFDir)
 
     print('Parameters:')
     print(sourcePDFFile)


### PR DESCRIPTION
I added some minor path handling facilities for non-windows users.
Let me know if it still works on Windows, though.
One still has to provide the output path as an empty string ("") even when one doesn't want the files to be saved in a separate folder. Maybe using `argparse` to make some arguments really optional.
Thank you for the initiative.
Milcent